### PR TITLE
Don't move cursor to the top on first undo

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -221,13 +221,24 @@ export default class Editor extends React.Component<Props, State> {
 
   private _undoEdit = () => {
     const { stack, offset } = this._history;
-
     // Get the previous edit
     const record = stack[offset - 1];
 
+    // Get the current record
+    const current = stack[offset];
+    let selectionStart = 0,
+      selectionEnd = 0;
+
+    // Get the diff
+    if (current?.value?.length && record?.value?.length) {
+      const diff = current.value.length - record.value.length;
+      selectionStart = current.selectionStart - diff;
+      selectionEnd = current.selectionEnd - diff;
+    }
+
     if (record) {
       // Apply the changes and update the offset
-      this._updateInput(record);
+      this._updateInput({ ...record, selectionStart, selectionEnd });
       this._history.offset = Math.max(offset - 1, 0);
     }
   };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Thanks for making and maintaining this library! We are using it for the demos on https://mui.com/. The first undo on a demo causes the cursor to reset back to the first position:


https://user-images.githubusercontent.com/19550456/208623219-89fce512-e324-4e55-9f13-b98f62ad6012.mov


### Test plan

Before:

https://user-images.githubusercontent.com/19550456/208623576-885d7401-e194-4eb3-a784-5fea7f4cf6ef.mov

After: 

https://user-images.githubusercontent.com/19550456/208623603-3d5eabc4-4610-4fb4-a87d-92627813e0ff.mov

