### PR TITLE
fix: broken link to demo on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The editor accepts all the props accepted by `textarea`. In addition, you can pa
 
 ## Demo
 
-[satya164.github.io/react-simple-code-editor](https://satya164.github.io/react-simple-code-editor)
+[react-simple-code-editor.github.io/react-simple-code-editor](https://react-simple-code-editor.github.io/react-simple-code-editor/)
 
 ## How it works
 


### PR DESCRIPTION
Fix #105

### Motivation

Demo link in readme.md file was pointing to a 404 page (well actually it was redirecting to the xyz domain first, then giving the 404 error.)
### Test plan

Test plan: Click on it :)