### PR TITLE
Added label to <textarea> to fix a11y issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   autoFocus?: boolean;
   disabled?: boolean;
   form?: string;
+  label?: string;
   maxLength?: number;
   minLength?: number;
   name?: string;
@@ -515,6 +516,7 @@ export default class Editor extends React.Component<Props, State> {
       autoFocus,
       disabled,
       form,
+      label,
       maxLength,
       minLength,
       name,
@@ -557,6 +559,7 @@ export default class Editor extends React.Component<Props, State> {
         />
         <textarea
           ref={(c) => (this._input = c)}
+          aria-label={label || 'Code Editor'}
           style={{
             ...styles.editor,
             ...styles.textarea,


### PR DESCRIPTION
### Motivation

This pull request adds an aria-label to resolve the a11y issue here: https://github.com/react-simple-code-editor/react-simple-code-editor/issues/103