### PR TITLE
Exposing rows property of text area

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,7 @@ type Props = React.HTMLAttributes<HTMLDivElement> & {
   onBlur?: React.FocusEventHandler<HTMLTextAreaElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>;
+  rows?: number;
 
   // Props for the hightlighted code’s pre element
   preClassName?: string;
@@ -533,6 +534,7 @@ export default class Editor extends React.Component<Props, State> {
       ignoreTabKey,
       /* eslint-enable @typescript-eslint/no-unused-vars */
       preClassName,
+      rows,
       ...rest
     } = this.props;
 
@@ -587,6 +589,7 @@ export default class Editor extends React.Component<Props, State> {
           autoCorrect="off"
           spellCheck={false}
           data-gramm={false}
+          rows={rows}
         />
         {/* eslint-disable-next-line react/no-danger */}
         <style dangerouslySetInnerHTML={{ __html: cssText }} />


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
Exposes the "rows" property of the text area as mentioned in https://github.com/react-simple-code-editor/react-simple-code-editor/issues/72

### Test plan
Specifying the rows property will limit the number of rows in the Editor. 


